### PR TITLE
Getting Errors When following Readme Instruction on ARM server with ubuntu24.04 #74

### DIFF
--- a/src/ggml-bitnet-lut.cpp
+++ b/src/ggml-bitnet-lut.cpp
@@ -1,6 +1,10 @@
 #include <vector>
 #include <type_traits>
 
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+
 #include "ggml-bitnet.h"
 #include "ggml-quants.h"
 #include "bitnet-lut-kernels.h"


### PR DESCRIPTION
Seems the developers forgot to commit these necessary libraries. The changes look safe for me, but I'm unable to verify it for x86 arch and Windows.

It's tested and works for MacBook Pro M3 (arm64), with TL1.

Please merge carefully.