### PR TITLE
docs: add git submodule update to enable successful pip install

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ cd BitNet
 conda create -n bitnet-cpp python=3.9
 conda activate bitnet-cpp
 
+git submodule update --init --recursive
+
 pip install -r requirements.txt
 ```
 3. Build the project


### PR DESCRIPTION
Add a command to pull git submodule `3rdparty` repository  before running pip install, so the pip install command will succeed.