### PR TITLE
Fix division-by-zero

### DIFF
--- a/preset_kernels/Llama3-8B-1.58-100B-tokens/bitnet-lut-kernels-tl1.h
+++ b/preset_kernels/Llama3-8B-1.58-100B-tokens/bitnet-lut-kernels-tl1.h
@@ -31,7 +31,7 @@ void per_tensor_quant(int k, void* lut_scales_, void* b_) {{
       float32x4_t abssum = vabsq_f32(vec_bs);
       temp_max = vmaxq_f32(abssum, temp_max);
     }}
-    float32_t scales = 127 / vmaxvq_f32(temp_max);
+    float32_t scales = 127 / (vmaxvq_f32(temp_max) + 1e-10f);
     *lut_scales = scales;
 #elif defined __AVX2__
     __m256 max_vec = _mm256_set1_ps(0.f);
@@ -45,7 +45,7 @@ void per_tensor_quant(int k, void* lut_scales_, void* b_) {{
     __m128 max1 = _mm_max_ps(_mm256_extractf128_ps(max_vec, 1), _mm256_castps256_ps128(max_vec));
     max1 = _mm_max_ps(max1, _mm_movehl_ps(max1, max1));
     max1 = _mm_max_ss(max1, _mm_movehdup_ps(max1));
-    float scales = 127 / _mm_cvtss_f32(max1);
+    float scales = 127 / (_mm_cvtss_f32(max1) + 1e-10f);
     *lut_scales = scales;
 #endif
 }}

--- a/preset_kernels/Llama3-8B-1.58-100B-tokens/bitnet-lut-kernels-tl2.h
+++ b/preset_kernels/Llama3-8B-1.58-100B-tokens/bitnet-lut-kernels-tl2.h
@@ -82,7 +82,7 @@ inline int32_t per_tensor_quant(int k, void* lut_scales_, void* b_) {
     __m128 max1 = _mm_max_ps(_mm256_extractf128_ps(max_vec, 1), _mm256_castps256_ps128(max_vec));
     max1 = _mm_max_ps(max1, _mm_movehl_ps(max1, max1));
     max1 = _mm_max_ss(max1, _mm_movehdup_ps(max1));
-    float scales = 127 / _mm_cvtss_f32(max1);
+    float scales = 127 / (_mm_cvtss_f32(max1) + 1e-10f);
     *lut_scales = scales;
 #endif
     return 0;

--- a/preset_kernels/bitnet_b1_58-3B/bitnet-lut-kernels-tl1.h
+++ b/preset_kernels/bitnet_b1_58-3B/bitnet-lut-kernels-tl1.h
@@ -31,7 +31,7 @@ void per_tensor_quant(int k, void* lut_scales_, void* b_) {{
       float32x4_t abssum = vabsq_f32(vec_bs);
       temp_max = vmaxq_f32(abssum, temp_max);
     }}
-    float32_t scales = 127 / vmaxvq_f32(temp_max);
+    float32_t scales = 127 / (vmaxvq_f32(temp_max) + 1e-10f);
     *lut_scales = scales;
 #elif defined __AVX2__
     __m256 max_vec = _mm256_set1_ps(0.f);
@@ -45,7 +45,7 @@ void per_tensor_quant(int k, void* lut_scales_, void* b_) {{
     __m128 max1 = _mm_max_ps(_mm256_extractf128_ps(max_vec, 1), _mm256_castps256_ps128(max_vec));
     max1 = _mm_max_ps(max1, _mm_movehl_ps(max1, max1));
     max1 = _mm_max_ss(max1, _mm_movehdup_ps(max1));
-    float scales = 127 / _mm_cvtss_f32(max1);
+    float scales = 127 / (_mm_cvtss_f32(max1) + 1e-10f);
     *lut_scales = scales;
 #endif
 }}

--- a/preset_kernels/bitnet_b1_58-3B/bitnet-lut-kernels-tl2.h
+++ b/preset_kernels/bitnet_b1_58-3B/bitnet-lut-kernels-tl2.h
@@ -82,7 +82,7 @@ inline int32_t per_tensor_quant(int k, void* lut_scales_, void* b_) {
     __m128 max1 = _mm_max_ps(_mm256_extractf128_ps(max_vec, 1), _mm256_castps256_ps128(max_vec));
     max1 = _mm_max_ps(max1, _mm_movehl_ps(max1, max1));
     max1 = _mm_max_ss(max1, _mm_movehdup_ps(max1));
-    float scales = 127 / _mm_cvtss_f32(max1);
+    float scales = 127 / (_mm_cvtss_f32(max1) + 1e-10f);
     *lut_scales = scales;
 #endif
     return 0;

--- a/preset_kernels/bitnet_b1_58-large/bitnet-lut-kernels-tl1.h
+++ b/preset_kernels/bitnet_b1_58-large/bitnet-lut-kernels-tl1.h
@@ -31,7 +31,7 @@ void per_tensor_quant(int k, void* lut_scales_, void* b_) {{
       float32x4_t abssum = vabsq_f32(vec_bs);
       temp_max = vmaxq_f32(abssum, temp_max);
     }}
-    float32_t scales = 127 / vmaxvq_f32(temp_max);
+    float32_t scales = 127 / (vmaxvq_f32(temp_max) + 1e-10f);
     *lut_scales = scales;
 #elif defined __AVX2__
     __m256 max_vec = _mm256_set1_ps(0.f);
@@ -45,7 +45,7 @@ void per_tensor_quant(int k, void* lut_scales_, void* b_) {{
     __m128 max1 = _mm_max_ps(_mm256_extractf128_ps(max_vec, 1), _mm256_castps256_ps128(max_vec));
     max1 = _mm_max_ps(max1, _mm_movehl_ps(max1, max1));
     max1 = _mm_max_ss(max1, _mm_movehdup_ps(max1));
-    float scales = 127 / _mm_cvtss_f32(max1);
+    float scales = 127 / (_mm_cvtss_f32(max1) + 1e-10f);
     *lut_scales = scales;
 #endif
 }}

--- a/preset_kernels/bitnet_b1_58-large/bitnet-lut-kernels-tl2.h
+++ b/preset_kernels/bitnet_b1_58-large/bitnet-lut-kernels-tl2.h
@@ -82,7 +82,7 @@ inline int32_t per_tensor_quant(int k, void* lut_scales_, void* b_) {
     __m128 max1 = _mm_max_ps(_mm256_extractf128_ps(max_vec, 1), _mm256_castps256_ps128(max_vec));
     max1 = _mm_max_ps(max1, _mm_movehl_ps(max1, max1));
     max1 = _mm_max_ss(max1, _mm_movehdup_ps(max1));
-    float scales = 127 / _mm_cvtss_f32(max1);
+    float scales = 127 / (_mm_cvtss_f32(max1) + 1e-10f);
     *lut_scales = scales;
 #endif
     return 0;


### PR DESCRIPTION
When quantizing the (input) activations to the bit-linear layer, `NaN`s may occur due to division by zero. This is a consequence of the formula in the original paper:
$Quant(x) = Clip(x \times \frac{Q_b}{||x||_\infty}, -Q_b + \epsilon, Q_b - \epsilon$

In the extreme case where all activations are zero, this will result in abs-max being zero, and thus a division by zero.

To fix this, I made sure to add `1e-10f` to all maxes in the preset kernels. In 99.99% of cases, this will be a minor (or no) change, but in problematic cases, this avoids `NaN`s.