### PR TITLE
Register BitNetForCausalLM as another spelling for BitnetForCausalLM in utils scripts

### DIFF
--- a/utils/convert-hf-to-gguf-bitnet.py
+++ b/utils/convert-hf-to-gguf-bitnet.py
@@ -949,7 +949,7 @@ class LlamaModel(Model):
                 raise ValueError(f"Unprocessed experts: {experts}")
 
 
-@Model.register("BitnetForCausalLM")
+@Model.register("BitnetForCausalLM", "BitNetForCausalLM"
 class BitnetModel(Model):
     model_arch = gguf.MODEL_ARCH.BITNET
 

--- a/utils/convert-hf-to-gguf-bitnet.py
+++ b/utils/convert-hf-to-gguf-bitnet.py
@@ -949,7 +949,7 @@ class LlamaModel(Model):
                 raise ValueError(f"Unprocessed experts: {experts}")
 
 
-@Model.register("BitnetForCausalLM", "BitNetForCausalLM"
+@Model.register("BitnetForCausalLM", "BitNetForCausalLM")
 class BitnetModel(Model):
     model_arch = gguf.MODEL_ARCH.BITNET
 

--- a/utils/generate-dummy-bitnet-model.py
+++ b/utils/generate-dummy-bitnet-model.py
@@ -773,7 +773,7 @@ def preprocess_weights_tl2(
     return weight
     
 
-@Model.register("BitnetForCausalLM", "BitNetForCausalLM"
+@Model.register("BitnetForCausalLM", "BitNetForCausalLM")
 class BitnetModel(Model):
     model_arch = gguf.MODEL_ARCH.BITNET
     params: str = ""

--- a/utils/generate-dummy-bitnet-model.py
+++ b/utils/generate-dummy-bitnet-model.py
@@ -773,7 +773,7 @@ def preprocess_weights_tl2(
     return weight
     
 
-@Model.register("BitnetForCausalLM")
+@Model.register("BitnetForCausalLM", "BitNetForCausalLM"
 class BitnetModel(Model):
     model_arch = gguf.MODEL_ARCH.BITNET
     params: str = ""


### PR DESCRIPTION
This feels like a waste of a good full request. 

Microsoft configured their newly released bitnet model as using the `BitNetForCausalLM` architecture ([see](https://huggingface.co/microsoft/bitnet-b1.58-2B-4T-bf16/blob/main/config.json#L3)) while the conversion script in `utils` and other community models refers to it as `BitnetForCausalLM` (lowercase `N`). This just adds `BitNetForCausalLM` as another valid architecture name to use in `convert-hf-to-gguf-bitnet.py` and `generate-dummy-bitnet-model.py`.

Should fixes #193 