### PR TITLE
Add Collab Notebook BitNet demo link to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [<img src="./assets/header_model_release.png" alt="BitNet Model on Hugging Face" width="800"/>](https://huggingface.co/microsoft/BitNet-b1.58-2B-4T)
 
-Try it out via this [demo](https://bitnet-demo.azurewebsites.net/), or [build and run](https://github.com/microsoft/BitNet?tab=readme-ov-file#build-from-source) it on your own CPU.
+Try it out via this [demo](https://bitnet-demo.azurewebsites.net/), [Collab notebook](https://colab.research.google.com/drive/1YWEISZD3OTr4L11g8-PK4l0H7dQXarUo#scrollTo=cIFDpd9TzsAM), or [build and run](https://github.com/microsoft/BitNet?tab=readme-ov-file#build-from-source) it on your own CPU.
 
 bitnet.cpp is the official inference framework for 1-bit LLMs (e.g., BitNet b1.58). It offers a suite of optimized kernels, that support **fast** and **lossless** inference of 1.58-bit models on CPU (with NPU and GPU support coming next).
 


### PR DESCRIPTION
Following #181 - this is a small update adding [a Collab notebook link](https://colab.research.google.com/drive/1YWEISZD3OTr4L11g8-PK4l0H7dQXarUo#scrollTo=cIFDpd9TzsAM)  to the README - which lets users install and explore BitNet without any local setup. 

Edit permissions for the notebook can be given to any additioal contributors.