### PR TITLE
fix: Improve grammar and clarify phrasing in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ python utils/e2e_benchmark.py -m /path/to/model -n 200 -p 256 -t 4
    
 This command would run the inference benchmark using the model located at `/path/to/model`, generating 200 tokens from a 256 token prompt, utilizing 4 threads.  
 
-For the model layout that do not supported by any public model, we provide scripts to generate a dummy model with the given model layout, and run the benchmark on your machine:
+For the model layouts that are not supported by any public model, we provide scripts to generate a dummy model with the given model layout, and run the benchmark on your machine:
 
 ```bash
 python utils/generate-dummy-bitnet-model.py models/bitnet_b1_58-large --outfile models/dummy-bitnet-125m.tl1.gguf --outtype tl1 --model-size 125M


### PR DESCRIPTION
### Description
This pull request addresses a grammatical error and improves the clarity of a sentence in the `README.md` file.

### Changes Made
- In the "Benchmark" section, the sentence "For the model layout that do not supported by any public model..." has been updated.
- The phrase "model layout that do not supported" has been corrected to "model layouts that are not supported" to:
    - Fix the grammatical error ("do not supported").
    - Use the plural form "layouts" with "are not supported" to refer more broadly to the class of unsupported model layouts, which is more accurate and natural for documentation.

### Reason for Change
The original phrasing contained a grammatical error and could be more clearly articulated. This fix enhances the readability and accuracy of the documentation by using correct grammar and more appropriate phrasing.