### PR TITLE
[build] involve parallel compiling

### DIFF
--- a/setup_env.py
+++ b/setup_env.py
@@ -213,7 +213,7 @@ def compile():
     logging.info("Compiling the code using CMake.")
     run_command(["cmake", "-B", "build", *COMPILER_EXTRA_ARGS[arch], *OS_EXTRA_ARGS.get(platform.system(), []), "-DCMAKE_C_COMPILER=clang", "-DCMAKE_CXX_COMPILER=clang++"], log_step="generate_build_files")
     # run_command(["cmake", "--build", "build", "--target", "llama-cli", "--config", "Release"])
-    run_command(["cmake", "--build", "build", "--config", "Release"], log_step="compile")
+    run_command(["cmake", "--build", "build", "--config", "Release", "--parallel", str(os.cpu_count())], log_step="compile")
 
 def main():
     setup_gguf()


### PR DESCRIPTION
# Description

On a low-ended ARM device, compiling the project with only single thread may got the process blocked for hours due to the low I/O rate of the ARM CPU instruction. To get rid of that, you need parallel building!

# Changes

Add "--parallel $(nproc)" to cmake argument.
