### PR TITLE
Fixed "Falcon3" Base Model Download Error

### DIFF
--- a/setup_env.py
+++ b/setup_env.py
@@ -23,19 +23,19 @@ SUPPORTED_HF_MODELS = {
     "tiiuae/Falcon3-7B-Instruct-1.58bit": {
         "model_name": "Falcon3-7B-Instruct-1.58bit",
     },
-    "tiiuae/Falcon3-7B-1.58bit": {
+    "tiiuae/Falcon3-7B-Base-1.58bit": {
         "model_name": "Falcon3-7B-1.58bit",
     },
     "tiiuae/Falcon3-10B-Instruct-1.58bit": {
         "model_name": "Falcon3-10B-Instruct-1.58bit",
     },
-    "tiiuae/Falcon3-10B-1.58bit": {
+    "tiiuae/Falcon3-10B-Base-1.58bit": {
         "model_name": "Falcon3-10B-1.58bit",
     },
     "tiiuae/Falcon3-3B-Instruct-1.58bit": {
         "model_name": "Falcon3-3B-Instruct-1.58bit",
     },
-    "tiiuae/Falcon3-3B-1.58bit": {
+    "tiiuae/Falcon3-3B-Base-1.58bit": {
         "model_name": "Falcon3-3B-1.58bit",
     },
     "tiiuae/Falcon3-1B-Instruct-1.58bit": {


### PR DESCRIPTION
Fixed error in `setup_env.py` that prevented downloading of **_Falcon3 Base_** models