### PR TITLE
docs: replace deprecated huggingface-cli with hf command

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ pip install -r requirements.txt
 3. Build the project
 ```bash
 # Manually download the model and run with local path
-huggingface-cli download microsoft/BitNet-b1.58-2B-4T-gguf --local-dir models/BitNet-b1.58-2B-4T
+hf download microsoft/BitNet-b1.58-2B-4T-gguf --local-dir models/BitNet-b1.58-2B-4T
 python setup_env.py -md models/BitNet-b1.58-2B-4T -q i2_s
 
 ```
@@ -297,7 +297,7 @@ python utils/e2e_benchmark.py -m models/dummy-bitnet-125m.tl1.gguf -p 512 -n 128
 
 ```sh
 # Prepare the .safetensors model file
-huggingface-cli download microsoft/bitnet-b1.58-2B-4T-bf16 --local-dir ./models/bitnet-b1.58-2B-4T-bf16
+hf download microsoft/bitnet-b1.58-2B-4T-bf16 --local-dir ./models/bitnet-b1.58-2B-4T-bf16
 
 # Convert to gguf model
 python ./utils/convert-helper-bitnet.py ./models/bitnet-b1.58-2B-4T-bf16

--- a/gpu/README.md
+++ b/gpu/README.md
@@ -34,7 +34,7 @@ End-to-end inference:
 ```bash
 # Download and convert the BitNet-b1.58-2B model
 mkdir checkpoints
-huggingface-cli download microsoft/bitnet-b1.58-2B-4T-bf16 --local-dir ./checkpoints/bitnet-b1.58-2B-4T-bf16
+hf download microsoft/bitnet-b1.58-2B-4T-bf16 --local-dir ./checkpoints/bitnet-b1.58-2B-4T-bf16
 python ./convert_safetensors.py --safetensors_file ./checkpoints/bitnet-b1.58-2B-4T-bf16/model.safetensors --output checkpoints/model_state.pt --model_name 2B
 python ./convert_checkpoint.py --input ./checkpoints/model_state.pt
 rm ./checkpoints/model_state.pt


### PR DESCRIPTION
## Summary
- Replace deprecated `huggingface-cli download` with `hf download` in README.md and gpu/README.md
- The huggingface-cli command now shows a deprecation warning directing users to use `hf` instead

Fixes #349