### PR TITLE
build: add pyproject.toml for modern Python packaging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,48 @@
+[project]
+name = "bitnet-cpp"
+version = "1.0.0"
+description = "Official inference framework for 1-bit LLMs (e.g., BitNet b1.58)"
+readme = "README.md"
+license = {text = "MIT"}
+requires-python = ">=3.9"
+authors = [
+    {name = "Microsoft", email = "bitnet@microsoft.com"}
+]
+keywords = ["llm", "1-bit", "inference", "bitnet"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
+
+dependencies = [
+    "numpy>=1.26.4,<2.0.0",
+    "sentencepiece>=0.2.0,<0.3.0",
+    "transformers>=4.46.3,<5.0.0",
+    "gguf>=0.1.0",
+    "protobuf>=4.21.0,<5.0.0",
+    "torch>=2.2.1,<3.0.0",
+]
+
+[project.urls]
+Homepage = "https://github.com/microsoft/BitNet"
+Repository = "https://github.com/microsoft/BitNet"
+Documentation = "https://github.com/microsoft/BitNet#readme"
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+py-modules = []
+
+[[tool.uv.index]]
+name = "pytorch-cpu"
+url = "https://download.pytorch.org/whl/cpu"


### PR DESCRIPTION
## Summary
- Add `pyproject.toml` for PEP 517/518 compliant builds
- Consolidates dependencies from 3rdparty/llama.cpp/requirements/ files
- Enables usage with modern package managers like `uv`

### Usage with uv
```bash
uv pip install .
```

This keeps `requirements.txt` for backward compatibility while providing a modern alternative.

Fixes #330