### PR TITLE
build: use C++17 standard for macOS compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,10 @@ option(BITNET_ARM_TL1    "bitnet.cpp: use tl1 on arm platform"    OFF)
 option(BITNET_X86_TL2    "bitnet.cpp: use tl2 on x86 platform"    OFF)
 
 
+# Use C++17 to support modern Apple SDK headers which require elaborated enum base
+# declarations not available in C++11. This fixes compilation on macOS with
+# recent Xcode/AppleClang versions. See issue #350.
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED true)
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED true)


### PR DESCRIPTION
## Summary
- Set `CMAKE_CXX_STANDARD` to 17 in the root CMakeLists.txt
- Fixes compilation on macOS with modern Xcode/AppleClang versions

## Problem
Modern Apple SDK headers (macOS 26+, Xcode 17+) use elaborated enum base declarations that require C++17:
```
error: non-defining declaration of enumeration with a fixed underlying type
       is only permitted as a standalone declaration
```

## Solution
The ggml submodule defaults to C++11 which doesn't support this syntax. Setting C++17 at the BitNet project level propagates to submodules and fixes the issue.

This has been confirmed working by @RobBW in issue #350 comments.

Fixes #350