### PR TITLE
[Security/Stability] Harden Codegen against Division by Zero and Null Pointers

### DIFF
--- a/utils/codegen_tl1.py
+++ b/utils/codegen_tl1.py
@@ -345,12 +345,26 @@ void ggml_bitnet_transform_tensor(struct ggml_tensor * tensor) {\n\
     }}\n".format(kernel_shapes[i][0], kernel_shapes[i][1])])
 
     kernel_code = "".join([kernel_code, "\n\
+    if (bm == 0) {{\n\
+        fprintf(stderr, \"ggml_bitnet_transform_tensor: unsupported tensor dimensions m=%d, k=%d\\n\", m, k);\n\
+        return;\n\
+    }}\n\
+\n\
+    if (tensor->data == nullptr) {{\n\
+        fprintf(stderr, \"ggml_bitnet_transform_tensor: tensor->data is null\\n\");\n\
+        return;\n\
+    }}\n\
+\n\
     const int n_tile_num = m / bm;\n\
     const int BK = bk;\n\
     uint8_t * qweights;\n\
     bitnet_float_type * scales;\n\
 \n\
     scales = (bitnet_float_type *) aligned_malloc(sizeof(bitnet_float_type));\n\
+    if (scales == nullptr) {{\n\
+        fprintf(stderr, \"ggml_bitnet_transform_tensor: failed to allocate scales\\n\");\n\
+        return;\n\
+    }}\n\
     qweights = (uint8_t *) tensor->data;\n\
     float * i2_scales = (float * )(qweights + k * m / 4);\n\
     scales[0] = (bitnet_float_type) i2_scales[0];\n\

--- a/utils/codegen_tl2.py
+++ b/utils/codegen_tl2.py
@@ -649,12 +649,26 @@ void ggml_bitnet_transform_tensor(struct ggml_tensor * tensor) {\n\
     }}\n".format(kernel_shapes[i][0], kernel_shapes[i][1])])
 
     kernel_code = "".join([kernel_code, "\n\
+    if (bm == 0) {{\n\
+        fprintf(stderr, \"ggml_bitnet_transform_tensor: unsupported tensor dimensions m=%d, k=%d\\n\", m, k);\n\
+        return;\n\
+    }}\n\
+\n\
+    if (tensor->data == nullptr) {{\n\
+        fprintf(stderr, \"ggml_bitnet_transform_tensor: tensor->data is null\\n\");\n\
+        return;\n\
+    }}\n\
+\n\
     const int n_tile_num = m / bm;\n\
     const int BK = bk;\n\
     uint8_t * qweights;\n\
     bitnet_float_type * scales;\n\
 \n\
     scales = (bitnet_float_type *) aligned_malloc(sizeof(bitnet_float_type));\n\
+    if (scales == nullptr) {{\n\
+        fprintf(stderr, \"ggml_bitnet_transform_tensor: failed to allocate scales\\n\");\n\
+        return;\n\
+    }}\n\
     qweights = (uint8_t *) tensor->data;\n\
     int nbytes = (k - 256) * m / 3 * 5 / 8 + 256 * m / 2 * 4 / 8;\n\
     if (nbytes % 32 != 0) nbytes = 32 - nbytes % 32 + nbytes;\n\


### PR DESCRIPTION
Improved the security and stability of generated BitNet kernels by adding mandatory validation logic in the transformation phase.

The Issues:
1. Division by Zero: Models with unsupported dimensions previously caused a crash ('m / 0') because 'bm' was left at 0.
2. Null Pointer Dereference: Lack of checks for 'tensor->data' and 'aligned_malloc' failure could lead to segmentation faults.
3. Memory Safety: Untested allocation of scales could result in crashes on low-memory systems.

The Fix:
- Patched 'utils/codegen_tl1.py' and 'utils/codegen_tl2.py' to include explicit checks and error messages ('fprintf') for these edge cases.
- Ensures the model fails gracefully with a clear error message instead of crashing the process.

Impact: significantly improves the robustness of the BitNet inference engine against malformed or unsupported GGUF models.