### PR TITLE
Fix model architecture name case mismatch breaking TL2 conversion

### DIFF
--- a/utils/convert-hf-to-gguf-bitnet.py
+++ b/utils/convert-hf-to-gguf-bitnet.py
@@ -952,7 +952,7 @@ class LlamaModel(Model):
                 raise ValueError(f"Unprocessed experts: {experts}")
 
 
-@Model.register("BitnetForCausalLM")
+@Model.register("BitNetForCausalLM")
 class BitnetModel(Model):
     model_arch = gguf.MODEL_ARCH.BITNET
 

--- a/utils/generate-dummy-bitnet-model.py
+++ b/utils/generate-dummy-bitnet-model.py
@@ -773,7 +773,7 @@ def preprocess_weights_tl2(
     return weight
     
 
-@Model.register("BitnetForCausalLM")
+@Model.register("BitNetForCausalLM")
 class BitnetModel(Model):
     model_arch = gguf.MODEL_ARCH.BITNET
     params: str = ""


### PR DESCRIPTION
## Summary
- Fixed `@Model.register("BitnetForCausalLM")` → `@Model.register("BitNetForCausalLM")` (capital 'N') in both `convert-hf-to-gguf-bitnet.py` and `generate-dummy-bitnet-model.py`
- HuggingFace model configs use `"BitNetForCausalLM"` as the architecture name, but the registration decorator had a lowercase 'n', causing the case-sensitive lookup in `from_model_architecture()` to fail with `NotImplementedError: Architecture 'BitNetForCausalLM' not supported!`
- This completely blocked TL2 model conversion (`python setup_env.py -md models/BitNet-b1.58-2B-4T -q tl2`)

## Test plan
- [ ] Run `python setup_env.py -md models/BitNet-b1.58-2B-4T -q tl2` and verify conversion completes without `NotImplementedError`
- [ ] Verify existing `i2_s` and `tl1` quantization paths still work

Fixes #300