### PR TITLE
Enable parallel compilation in setup_env.py

### DIFF
--- a/setup_env.py
+++ b/setup_env.py
@@ -213,7 +213,7 @@ def compile():
     logging.info("Compiling the code using CMake.")
     run_command(["cmake", "-B", "build", *COMPILER_EXTRA_ARGS[arch], *OS_EXTRA_ARGS.get(platform.system(), []), "-DCMAKE_C_COMPILER=clang", "-DCMAKE_CXX_COMPILER=clang++"], log_step="generate_build_files")
     # run_command(["cmake", "--build", "build", "--target", "llama-cli", "--config", "Release"])
-    run_command(["cmake", "--build", "build", "--config", "Release"], log_step="compile")
+    run_command(["cmake", "--build", "build", "--config", "Release", "--parallel"], log_step="compile")
 
 def main():
     setup_gguf()


### PR DESCRIPTION
## Summary
- Added `--parallel` flag to the `cmake --build` command in `setup_env.py`
- Without this flag, cmake defaults to single-threaded compilation, which can take hours on low-end ARM devices
- With `--parallel`, cmake automatically uses all available CPU cores

## Test plan
- [ ] Run `python setup_env.py -md models/BitNet-b1.58-2B-4T -q i2_s` and verify build completes using multiple cores
- [ ] Verify build still succeeds on Windows (Visual Studio generator) and Linux/macOS (Make/Ninja generators)

Fixes #303