### PR TITLE
Fix LLVM optimization bug causing infinite build on Apple Silicon

### DIFF
--- a/setup_env.py
+++ b/setup_env.py
@@ -211,7 +211,15 @@ def compile():
         logging.error(f"Arch {arch} is not supported yet")
         exit(0)
     logging.info("Compiling the code using CMake.")
-    run_command(["cmake", "-B", "build", *COMPILER_EXTRA_ARGS[arch], *OS_EXTRA_ARGS.get(platform.system(), []), "-DCMAKE_C_COMPILER=clang", "-DCMAKE_CXX_COMPILER=clang++"], log_step="generate_build_files")
+    cmake_args = ["cmake", "-B", "build", *COMPILER_EXTRA_ARGS[arch], *OS_EXTRA_ARGS.get(platform.system(), []), "-DCMAKE_C_COMPILER=clang", "-DCMAKE_CXX_COMPILER=clang++"]
+
+    # Work around LLVM InterleavedLoadCombine optimization bug on Apple Silicon
+    # that causes infinite recursion during compilation (see issue #294, #251, #260)
+    if platform.system() == "Darwin" and arch == "arm64":
+        llvm_flags = "-mllvm -disable-interleaved-load-combine"
+        cmake_args += [f"-DCMAKE_C_FLAGS={llvm_flags}", f"-DCMAKE_CXX_FLAGS={llvm_flags}"]
+
+    run_command(cmake_args, log_step="generate_build_files")
     # run_command(["cmake", "--build", "build", "--target", "llama-cli", "--config", "Release"])
     run_command(["cmake", "--build", "build", "--config", "Release"], log_step="compile")
 


### PR DESCRIPTION
## Summary
- Added `-mllvm -disable-interleaved-load-combine` compiler flags to `setup_env.py` for macOS ARM64 builds
- LLVM's `InterleavedLoadCombine` optimization pass triggers infinite recursion on Apple Silicon when compiling BitNet's vector shuffle patterns, causing the build to hang indefinitely
- This has been reported across multiple LLVM versions (Apple Clang 17.0.0, Homebrew Clang 20.1.6) and affects M1/M2/M4 chips
- The fix is scoped to `Darwin + arm64` only, so it does not affect x86, Linux, or Windows builds

## Related issues
- #251 (build running for hours)
- #260 (build running for hours)

## Test plan
- [ ] Run `python setup_env.py -md models/BitNet-b1.58-2B-4T -q i2_s` on Apple Silicon Mac — verify build completes in minutes, not hours
- [ ] Verify build still works on x86_64 Linux/Windows (no flags added on those platforms)
- [ ] Run inference after build to verify model correctness is unaffected

Fixes #294