### PR TITLE
fix: resolve const-correctness error in ggml-bitnet-mad.cpp

### DIFF
--- a/src/ggml-bitnet-mad.cpp
+++ b/src/ggml-bitnet-mad.cpp
@@ -808,7 +808,7 @@ void ggml_vec_dot_i2_i8_s_Nx1(int n, float * s, size_t bs, const void * vx, size
             accu[iy] = _mm256_setzero_si256();
         }
 
-        int8_t * y_col = y + col * by;
+        const int8_t * y_col = y + col * by;
         
         for (int i = 0; i < group32_num; i++) {
             const uint8_t *px = x + i * 1024;


### PR DESCRIPTION
Fixes the following build error:
ggml-bitnet-mad.cpp:811:17: error: cannot initialize a variable of type 'int8_t *' with an rvalue of type 'const int8_t *'

Changed `int8_t *y_col` to `const int8_t *y_col` to respect const correctness, as `y` is a const input pointer and its data should not be modified.