### PR TITLE
build: support Python 3.13 conversion dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@
 #
 
 -r 3rdparty/llama.cpp/requirements/requirements-convert_legacy_llama.txt
--r 3rdparty/llama.cpp/requirements/requirements-convert_hf_to_gguf.txt
--r 3rdparty/llama.cpp/requirements/requirements-convert_hf_to_gguf_update.txt
+-r requirements/requirements-convert_hf_to_gguf.txt
+-r requirements/requirements-convert_hf_to_gguf_update.txt
 -r 3rdparty/llama.cpp/requirements/requirements-convert_llama_ggml_to_gguf.txt
--r 3rdparty/llama.cpp/requirements/requirements-convert_lora_to_gguf.txt
+-r requirements/requirements-convert_lora_to_gguf.txt

--- a/requirements/requirements-convert_hf_to_gguf.txt
+++ b/requirements/requirements-convert_hf_to_gguf.txt
@@ -1,0 +1,4 @@
+-r ../3rdparty/llama.cpp/requirements/requirements-convert_legacy_llama.txt
+--extra-index-url https://download.pytorch.org/whl/cpu
+torch~=2.2.1; python_version < "3.13"
+torch>=2.5.0,<3.0.0; python_version >= "3.13"

--- a/requirements/requirements-convert_hf_to_gguf_update.txt
+++ b/requirements/requirements-convert_hf_to_gguf_update.txt
@@ -1,0 +1,4 @@
+-r ../3rdparty/llama.cpp/requirements/requirements-convert_legacy_llama.txt
+--extra-index-url https://download.pytorch.org/whl/cpu
+torch~=2.2.1; python_version < "3.13"
+torch>=2.5.0,<3.0.0; python_version >= "3.13"

--- a/requirements/requirements-convert_lora_to_gguf.txt
+++ b/requirements/requirements-convert_lora_to_gguf.txt
@@ -1,0 +1,2 @@
+-r ./requirements-convert_hf_to_gguf.txt
+--extra-index-url https://download.pytorch.org/whl/cpu


### PR DESCRIPTION
## Summary
Fix installation on Python 3.13 for the conversion dependency set used by BitNet's top-level `requirements.txt`.

## Root cause
BitNet's top-level requirements included vendored `llama.cpp` requirement files that pin `torch~=2.2.1`. That torch line does not provide `cp313` wheels, so `uv pip install -r requirements.txt` fails on Python 3.13 with an unsatisfiable dependency resolution error.

## Changes
- Route top-level conversion requirement includes through BitNet-local wrapper files instead of referencing the vendored `llama.cpp` files directly
- Keep `torch~=2.2.1` for Python `<3.13`
- Use `torch>=2.5.0,<3.0.0` for Python `>=3.13`
- Apply the same logic to the LoRA conversion path so top-level installs remain consistent and do not reintroduce the old torch pin transitively

## Why this approach
The torch incompatibility exists in vendored submodule requirement files, but BitNet consumes those files through its own top-level `requirements.txt`. Using BitNet-local wrappers fixes installation behavior without modifying the submodule directly.

## Verification
### Before
On clean `main`:
```bash
git submodule update --init --recursive
uv venv --python 3.13 --seed .venv-py313
uv pip install --python .venv-py313/bin/python -r requirements.txt
```

Result:
- fails on Python 3.13
- resolver reports that `torch~=2.2.1` has no matching `cp313` wheels

### After
On this branch:
```bash
git submodule update --init --recursive
uv venv --python 3.13 --seed .venv-py313
uv pip install --python .venv-py313/bin/python -r requirements.txt
```

Result:
- succeeds on Python 3.13
- resolves `torch==2.10.0`

Regression check:
```bash
uv venv --python 3.12 --seed .venv-py312
uv pip install --python .venv-py312/bin/python -r requirements.txt
```

Result:
- still succeeds on Python 3.12
- resolves `torch==2.2.2`

Closes #413