### PR TITLE
build: fix const correctness in ggml-bitnet-mad

### DIFF
--- a/src/ggml-bitnet-mad.cpp
+++ b/src/ggml-bitnet-mad.cpp
@@ -808,7 +808,7 @@ void ggml_vec_dot_i2_i8_s_Nx1(int n, float * s, size_t bs, const void * vx, size
             accu[iy] = _mm256_setzero_si256();
         }
 
-        int8_t * y_col = y + col * by;
+        const int8_t * y_col = y + col * by;
         
         for (int i = 0; i < group32_num; i++) {
             const uint8_t *px = x + i * 1024;


### PR DESCRIPTION
## Summary
Fix a clang compiler error in `src/ggml-bitnet-mad.cpp` caused by dropping const qualification from a pointer derived from `const int8_t * y`.

## Root cause
`y` is declared as `const int8_t *`, so `y + col * by` is also `const int8_t *`. The code assigned that expression to `int8_t * y_col`, which discards const qualification and fails to compile on clang.

## Change
- Change `int8_t * y_col` to `const int8_t * y_col`

## Verification
- Ran a targeted syntax check with Apple clang on macOS arm64:
```bash
clang++ -std=c++17 -fsyntax-only -Iinclude -I./src -I./3rdparty/llama.cpp -I./3rdparty/llama.cpp/include -I./3rdparty/llama.cpp/ggml/include -I./3rdparty/llama.cpp/ggml/src src/ggml-bitnet-mad.cpp
```
- Full CMake configure in the repo is currently blocked by the separate open issue `#378` (`include/bitnet-lut-kernels.h` missing), so validation here was limited to the affected translation unit.

Closes #407