### PR TITLE
build: allow CMake configure without generated LUT header

### DIFF
--- a/include/bitnet-lut-kernels.h
+++ b/include/bitnet-lut-kernels.h
@@ -1,0 +1,5 @@
+#pragma once
+
+// This file is overwritten by setup_env.py/codegen for TL1/TL2 kernel builds.
+// Keep a checked-in placeholder so default CMake configuration can succeed
+// before model-specific kernel generation has been run.

--- a/src/ggml-bitnet-lut.cpp
+++ b/src/ggml-bitnet-lut.cpp
@@ -7,7 +7,10 @@
 
 #include "ggml-bitnet.h"
 #include "ggml-quants.h"
+
+#if defined(GGML_BITNET_ARM_TL1) || defined(GGML_BITNET_X86_TL2)
 #include "bitnet-lut-kernels.h"
+#endif
 
 #if defined(GGML_BITNET_ARM_TL1)
 
@@ -163,5 +166,64 @@ int ggml_bitnet_get_type_bits(enum ggml_type type) {
         default:
             return 0;
     }
+}
+#endif
+
+#if !defined(GGML_BITNET_ARM_TL1) && !defined(GGML_BITNET_X86_TL2)
+void ggml_bitnet_init(void) {
+}
+
+void ggml_bitnet_free(void) {
+}
+
+bool ggml_bitnet_can_mul_mat(const struct ggml_tensor * src0, const struct ggml_tensor * src1, const struct ggml_tensor * dst) {
+    (void) src0;
+    (void) src1;
+    (void) dst;
+    return false;
+}
+
+size_t ggml_bitnet_mul_mat_get_wsize(const struct ggml_tensor * src0, const struct ggml_tensor * src1, const struct ggml_tensor * dst) {
+    (void) src0;
+    (void) src1;
+    (void) dst;
+    return 0;
+}
+
+void ggml_bitnet_mul_mat_task_init(void * src1, void * qlut, void * lut_scales, void * lut_biases, int n, int k, int m, int bits) {
+    (void) src1;
+    (void) qlut;
+    (void) lut_scales;
+    (void) lut_biases;
+    (void) n;
+    (void) k;
+    (void) m;
+    (void) bits;
+}
+
+void ggml_bitnet_mul_mat_task_compute(void * src0, void * scales, void * qlut, void * lut_scales, void * lut_biases, void * dst, int n, int k, int m, int bits) {
+    (void) src0;
+    (void) scales;
+    (void) qlut;
+    (void) lut_scales;
+    (void) lut_biases;
+    (void) dst;
+    (void) n;
+    (void) k;
+    (void) m;
+    (void) bits;
+}
+
+void ggml_bitnet_transform_tensor(struct ggml_tensor * tensor) {
+    (void) tensor;
+}
+
+int ggml_bitnet_get_type_bits(enum ggml_type type) {
+    (void) type;
+    return 0;
+}
+
+void ggml_bitnet_set_n_threads(int n_threads) {
+    (void) n_threads;
 }
 #endif


### PR DESCRIPTION
## Summary
Fix clean-clone CMake configuration when `include/bitnet-lut-kernels.h` has not been generated yet.

## Root cause
The build always included `include/bitnet-lut-kernels.h` and `src/ggml-bitnet-lut.cpp`, but `include/bitnet-lut-kernels.h` is only produced later by `setup_env.py` / codegen for TL1/TL2 builds. In a fresh clone, `cmake -S . -B build` failed before users had a chance to run model-specific kernel generation.

## Changes
- Add a checked-in placeholder `include/bitnet-lut-kernels.h`
- Only include `bitnet-lut-kernels.h` from `ggml-bitnet-lut.cpp` when `GGML_BITNET_ARM_TL1` or `GGML_BITNET_X86_TL2` is enabled
- Provide no-op fallback definitions for the LUT entry points when neither TL1 nor TL2 is enabled

## Why this approach
This fixes the clean-clone build in the BitNet repo without modifying the vendored `llama.cpp` submodule. When `setup_env.py` generates or copies model-specific LUT kernels, it still overwrites `include/bitnet-lut-kernels.h` as before.

## Verification
### Before
On a clean clone:
```bash
git submodule update --init --recursive
cmake -S . -B build
```

Result:
- fails during configure with missing `include/bitnet-lut-kernels.h`

### After
On this branch:
```bash
git submodule update --init --recursive
cmake -S . -B build
cmake --build build --config Release -j4
```

Result:
- configure succeeds
- full build succeeds on macOS arm64

Closes #378