### PR TITLE
fix: const-correctness in ggml-bitnet-mad.cpp + missing chrono includes (fixes #334)

### DIFF
--- a/src/ggml-bitnet-mad.cpp
+++ b/src/ggml-bitnet-mad.cpp
@@ -808,7 +808,7 @@ void ggml_vec_dot_i2_i8_s_Nx1(int n, float * s, size_t bs, const void * vx, size
             accu[iy] = _mm256_setzero_si256();
         }
 
-        int8_t * y_col = y + col * by;
+        const int8_t * y_col = y + col * by;
         
         for (int i = 0; i < group32_num; i++) {
             const uint8_t *px = x + i * 1024;


### PR DESCRIPTION
## Summary

Two build fixes for ClangCL (Windows) and strict compilers:

### 1. const-correctness in ggml-bitnet-mad.cpp (this commit)

Line 811 assigns `const int8_t* y` to `int8_t* y_col`, dropping the const qualifier. ClangCL and GCC with -Werror reject this.

**Fix:** `int8_t * y_col = y` -> `const int8_t * y_col = y`

### 2. Missing `#include <chrono>` in llama.cpp submodule (fixes #334)

Two files in the llama.cpp submodule use `std::chrono` without including `<chrono>`. This compiles on GCC/MSVC (transitive includes) but fails on ClangCL.

**Files needing fix:**
- `3rdparty/llama.cpp/common/common.cpp` (line 445: `std::chrono::system_clock`)
- `3rdparty/llama.cpp/common/log.cpp` (line 28: `std::chrono::system_clock`)

**Fix:** Add `#include <chrono>` to both files. Since these are in the llama.cpp submodule (`Eddie-Wang1120/llama.cpp`), the fix needs to be applied there and the submodule ref updated. The diff for each file is trivial — just add `#include <chrono>` with the other standard library includes.

### Verification

Both fixes are validated in CI across macOS ARM64, Linux x64, and Windows x64:
https://github.com/redhole-org/bitnet-builds/actions