### PR TITLE
fix: preserve constness for AVX2 y column pointer

### DIFF
--- a/src/ggml-bitnet-mad.cpp
+++ b/src/ggml-bitnet-mad.cpp
@@ -808,7 +808,7 @@ void ggml_vec_dot_i2_i8_s_Nx1(int n, float * s, size_t bs, const void * vx, size
             accu[iy] = _mm256_setzero_si256();
         }
 
-        int8_t * y_col = y + col * by;
+        const int8_t * y_col = y + col * by;
         
         for (int i = 0; i < group32_num; i++) {
             const uint8_t *px = x + i * 1024;


### PR DESCRIPTION
## Summary
- make the AVX2 `y_col` pointer const-correct in `src/ggml-bitnet-mad.cpp`
- fix the clang build error reported in #407 when `y` is treated as `const int8_t *`

## Validation
- `clang++ -std=c++17 -target x86_64-apple-darwin -isysroot "$(xcrun --sdk macosx --show-sdk-path)" -Iinclude -I3rdparty/llama.cpp/ggml/include -I3rdparty/llama.cpp/ggml/src -I3rdparty/llama.cpp/include -I3rdparty/llama.cpp/src -mavx2 -c src/ggml-bitnet-mad.cpp -o /tmp/ggml-bitnet-mad.o`
- `git diff --check`

Fixes #407.
