### PR TITLE
fix: resolve build failures on Linux with Clang 18 (const qualifier + OpenMP linker)

### DIFF
--- a/setup_env.py
+++ b/setup_env.py
@@ -200,6 +200,27 @@ def gen_code():
             raise NotImplementedError()
 
 
+def _find_clang():
+    """Find the best Clang/Clang++ available for BitNet compilation.
+
+    On Linux, prefers versioned installs (clang-18, clang-17, …) over the
+    bare 'clang' alias.  Distro-packaged versioned compilers (e.g. from
+    llvm.org or apt) ship a matching libomp that the linker can resolve.
+    Using a mismatched 'clang' (e.g. from Homebrew on a Linux host) links
+    against a different libomp that may not be on the system library path,
+    causing undefined-symbol errors at link time.
+
+    Falls back to unversioned 'clang'/'clang++' on non-Linux platforms
+    (macOS, Windows) where the version-suffixed binaries are not standard.
+    """
+    if platform.system() == "Linux":
+        for ver in ["18", "17", "16", "15"]:
+            if shutil.which(f"clang-{ver}") and shutil.which(f"clang++-{ver}"):
+                logging.info(f"Using clang-{ver}/clang++-{ver}")
+                return f"clang-{ver}", f"clang++-{ver}"
+    return "clang", "clang++"
+
+
 def compile():
     # Check if cmake is installed
     cmake_exists = subprocess.run(["cmake", "--version"], capture_output=True)
@@ -211,7 +232,8 @@ def compile():
         logging.error(f"Arch {arch} is not supported yet")
         exit(0)
     logging.info("Compiling the code using CMake.")
-    run_command(["cmake", "-B", "build", *COMPILER_EXTRA_ARGS[arch], *OS_EXTRA_ARGS.get(platform.system(), []), "-DCMAKE_C_COMPILER=clang", "-DCMAKE_CXX_COMPILER=clang++"], log_step="generate_build_files")
+    c_compiler, cxx_compiler = _find_clang()
+    run_command(["cmake", "-B", "build", *COMPILER_EXTRA_ARGS[arch], *OS_EXTRA_ARGS.get(platform.system(), []), f"-DCMAKE_C_COMPILER={c_compiler}", f"-DCMAKE_CXX_COMPILER={cxx_compiler}"], log_step="generate_build_files")
     # run_command(["cmake", "--build", "build", "--target", "llama-cli", "--config", "Release"])
     run_command(["cmake", "--build", "build", "--config", "Release"], log_step="compile")
 

--- a/src/ggml-bitnet-mad.cpp
+++ b/src/ggml-bitnet-mad.cpp
@@ -808,7 +808,7 @@ void ggml_vec_dot_i2_i8_s_Nx1(int n, float * s, size_t bs, const void * vx, size
             accu[iy] = _mm256_setzero_si256();
         }
 
-        int8_t * y_col = y + col * by;
+        const int8_t * y_col = y + col * by;
         
         for (int i = 0; i < group32_num; i++) {
             const uint8_t *px = x + i * 1024;


### PR DESCRIPTION
## Summary

Two related build failures on Linux systems with Clang 18.

---

### Fix 1 — `const` qualifier on `y_col` (`ggml-bitnet-mad.cpp:811`)

**Problem:** `ggml_vec_dot_i2_i8_s_Nx1` receives `vy` as `const void *`. Pointer arithmetic on the cast value yields `const int8_t *`, but the local variable `y_col` was declared as `int8_t *`, silently dropping the const qualifier. Clang 18 rejects this as an error; GCC and older Clang accepted it silently.

**Fix:** Declare `y_col` as `const int8_t *` to correctly propagate the const qualifier. Zero behavioral change.

```
error: cannot initialize a variable of type 'int8_t *' with an rvalue of type 'const int8_t *'
    int8_t * y_col = y + col * by;
```

---

### Fix 2 — Auto-detect versioned Clang on Linux (`setup_env.py`)

**Problem:** On Linux systems where both a distro-packaged `clang-18` (apt/llvm.org) and an alternative `clang` (e.g. Homebrew) are installed, the bare `clang` alias may resolve to a binary that links against a different `libomp` than the one installed by the OS. This causes a linker error at build time:

```
undefined reference to `__kmpc_fork_call@VERSION`
```

**Root cause:** Each Clang distribution ships its own `libomp`. Distro-packaged versioned binaries (`clang-18`, `clang-17`, ...) are guaranteed to pair with the correct `libomp`.

**Fix:** Add `_find_clang()` which probes for versioned Clang/Clang++ binaries (18 → 17 → 16 → 15) on Linux before falling back to bare `clang`/`clang++`. Non-Linux platforms (macOS, Windows) are unaffected.

Tested on: Ubuntu 24.04 with `apt install clang-18 libomp-18-dev`, x86_64, model `Falcon3-10B-Instruct-1.58bit`.

---

### Checklist
- [x] Both changes are backward-compatible
- [x] No new dependencies added
- [x] Tested end-to-end: `setup_env.py --hf-repo tiiuae/Falcon3-10B-Instruct-1.58bit` builds and runs inference successfully after both fixes