### PR TITLE
Add Dockerfile for containerized deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# BitNet.cpp Docker Image
+# For running 1-bit LLM inference on CPU
+
+FROM python:3.11-slim
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y \
+    cmake \
+    build-essential \
+    git \
+    wget \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set working directory
+WORKDIR /app
+
+# Copy project files
+COPY . .
+
+# Initialize git submodules
+RUN git submodule update --init --recursive
+
+# Build the project
+RUN cmake -B build && cmake --build build --config Release
+
+# Set environment variables
+ENV PYTHONPATH=/app/build/bin:$PYTHONPATH
+
+# Default command - show help
+CMD ["python3", "run_inference.py", "--help"]


### PR DESCRIPTION
## Summary
Adds a Dockerfile to enable containerized deployment of BitNet.cpp for running 1-bit LLM inference on CPU.

## Changes
- Added `Dockerfile` based on `python:3.11-slim`
- Includes build dependencies (cmake, build-essential, git)
- Initializes git submodules
- Builds the project with CMake

## Motivation
This resolves #433 - enables running BitNet on Kubernetes and other containerized infrastructure.

## Testing
The Dockerfile can be built with:
```bash
docker build -t bitnet .
```

Closes #433