### PR TITLE
Fix Windows compilation issue in ggml-bitnet-mad

### DIFF
--- a/src/ggml-bitnet-mad.cpp
+++ b/src/ggml-bitnet-mad.cpp
@@ -808,7 +808,7 @@ void ggml_vec_dot_i2_i8_s_Nx1(int n, float * s, size_t bs, const void * vx, size
             accu[iy] = _mm256_setzero_si256();
         }
 
-        int8_t * y_col = y + col * by;
+        const int8_t * y_col = y + col * by;
         
         for (int i = 0; i < group32_num; i++) {
             const uint8_t *px = x + i * 1024;


### PR DESCRIPTION
This PR fixes a Windows compilation issue in `src/ggml-bitnet-mad.cpp`.

When building BitNet on Windows with MSVC/Clang, the code fails due to a const pointer type mismatch.  
This change corrects the pointer type so the project builds successfully.

Tested locally on Windows with Python 3.12 using the `setup_env.py` pipeline.