### PR TITLE
fix: move sys.exit(1) inside except block in run_command()

### DIFF
--- a/setup_env.py
+++ b/setup_env.py
@@ -104,7 +104,7 @@ def run_command(command, shell=False, log_step=None):
             subprocess.run(command, shell=shell, check=True)
         except subprocess.CalledProcessError as e:
             logging.error(f"Error occurred while running command: {e}")
-        sys.exit(1)
+            sys.exit(1)
 
 def prepare_model():
     _, arch = system_info()

--- a/utils/e2e_benchmark.py
+++ b/utils/e2e_benchmark.py
@@ -20,7 +20,7 @@ def run_command(command, shell=False, log_step=None):
             subprocess.run(command, shell=shell, check=True)
         except subprocess.CalledProcessError as e:
             logging.error(f"Error occurred while running command: {e}")
-        sys.exit(1)
+            sys.exit(1)
 
 def run_benchmark():
     build_dir =  os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "build")


### PR DESCRIPTION
Fixes #447

`sys.exit(1)` was outside the `except` block due to indentation, so it ran unconditionally after `subprocess.run()` — even when the command succeeded. This caused the setup pipeline and benchmarks to always exit with code 1 after the first command that runs without a `log_step`.

The `log_step` branch (with log file) already has the correct indentation. This just aligns the `else` branch to match.

**Files changed:**
- `setup_env.py` — line 107
- `utils/e2e_benchmark.py` — line 23