### PR TITLE
Fix: ensure bitnet-lut-kernels.h prepared before llama.cpp build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,8 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 # option list
 option(BITNET_ARM_TL1    "bitnet.cpp: use tl1 on arm platform"    OFF)
 option(BITNET_X86_TL2    "bitnet.cpp: use tl2 on x86 platform"    OFF)
+set(BITNET_PRESET_KERNEL_MODEL "bitnet_b1_58-3B" CACHE STRING "Preset kernel model used to prepare include/bitnet-lut-kernels.h")
+set(BITNET_LUT_KERNELS_FILE "" CACHE FILEPATH "Optional path to a pre-generated bitnet-lut-kernels.h file")
 
 
 set(CMAKE_CXX_STANDARD_REQUIRED true)
@@ -34,6 +36,39 @@ endif()
 
 if (CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     add_compile_options(-fpermissive)
+endif()
+
+set(BITNET_LUT_KERNELS_DST "${CMAKE_CURRENT_SOURCE_DIR}/include/bitnet-lut-kernels.h")
+if (NOT EXISTS "${BITNET_LUT_KERNELS_DST}")
+    file(MAKE_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+    if (BITNET_LUT_KERNELS_FILE)
+        if (NOT EXISTS "${BITNET_LUT_KERNELS_FILE}")
+            message(FATAL_ERROR "BITNET_LUT_KERNELS_FILE does not exist: ${BITNET_LUT_KERNELS_FILE}")
+        endif()
+        configure_file("${BITNET_LUT_KERNELS_FILE}" "${BITNET_LUT_KERNELS_DST}" COPYONLY)
+        message(STATUS "Prepared bitnet-lut-kernels.h from BITNET_LUT_KERNELS_FILE=${BITNET_LUT_KERNELS_FILE}")
+    else()
+        set(BITNET_LUT_KERNEL_VARIANT "tl2")
+        if (GGML_BITNET_ARM_TL1)
+            set(BITNET_LUT_KERNEL_VARIANT "tl1")
+        elseif (GGML_BITNET_X86_TL2)
+            set(BITNET_LUT_KERNEL_VARIANT "tl2")
+        elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64)")
+            set(BITNET_LUT_KERNEL_VARIANT "tl1")
+        endif()
+
+        set(BITNET_PRESET_KERNEL_HEADER "${CMAKE_CURRENT_SOURCE_DIR}/preset_kernels/${BITNET_PRESET_KERNEL_MODEL}/bitnet-lut-kernels-${BITNET_LUT_KERNEL_VARIANT}.h")
+        if (NOT EXISTS "${BITNET_PRESET_KERNEL_HEADER}")
+            message(FATAL_ERROR
+                "bitnet-lut-kernels.h is missing and no valid preset header was found. "
+                "Expected: ${BITNET_PRESET_KERNEL_HEADER}. "
+                "Set BITNET_LUT_KERNELS_FILE to a generated header or BITNET_PRESET_KERNEL_MODEL to an available preset.")
+        endif()
+
+        configure_file("${BITNET_PRESET_KERNEL_HEADER}" "${BITNET_LUT_KERNELS_DST}" COPYONLY)
+        message(STATUS "Prepared bitnet-lut-kernels.h from preset model=${BITNET_PRESET_KERNEL_MODEL}, variant=${BITNET_LUT_KERNEL_VARIANT}")
+    endif()
 endif()
 
 find_package(Threads REQUIRED)


### PR DESCRIPTION

**Title:** Fix CMake build: ensure `bitnet-lut-kernels.h` prepared before llama.cpp

**Summary**  
The CMake build currently fails because `include/bitnet-lut-kernels.h` is required at configure time but is not tracked in the source tree. This header is produced by setup scripts (`setup_env.py`, codegen utilities) and not by CMake itself, which breaks a clean `cmake .. && make` workflow.

**Problem**  
- `bitnet-lut-kernels.h` is missing during CMake configure.  
- ggml’s CMakeLists expects the header before `add_subdirectory(3rdparty/llama.cpp)`.  
- Contributors running plain CMake builds hit a fatal error without running setup scripts first.

**Fix Implemented**  
fixes: #378 
- Updated top‑level `CMakeLists.txt` to ensure `include/bitnet-lut-kernels.h` exists before llama.cpp is added.  
- Added two cache variables:  
  - `BITNET_PRESET_KERNEL_MODEL` (default: `bitnet_b1_58-3B`)  
  - `BITNET_LUT_KERNELS_FILE` (optional explicit header path)  
- Behavior:  
  - If header already exists → leave untouched.  
  - If `BITNET_LUT_KERNELS_FILE` is set → copy that file.  
  - Else → auto‑copy from `preset_kernels/<model>/bitnet-lut-kernels-{tl1|tl2}.h` based on architecture.  
  - If nothing valid is found → clear fatal error with guidance.
