### PR TITLE
Fix: sys.exit(1) runs unconditionally due to indentation bug

### DIFF
--- a/setup_env.py
+++ b/setup_env.py
@@ -104,7 +104,7 @@ def run_command(command, shell=False, log_step=None):
             subprocess.run(command, shell=shell, check=True)
         except subprocess.CalledProcessError as e:
             logging.error(f"Error occurred while running command: {e}")
-        sys.exit(1)
+            sys.exit(1)
 
 def prepare_model():
     _, arch = system_info()

--- a/utils/e2e_benchmark.py
+++ b/utils/e2e_benchmark.py
@@ -20,7 +20,7 @@ def run_command(command, shell=False, log_step=None):
             subprocess.run(command, shell=shell, check=True)
         except subprocess.CalledProcessError as e:
             logging.error(f"Error occurred while running command: {e}")
-        sys.exit(1)
+            sys.exit(1)
 
 def run_benchmark():
     build_dir =  os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "build")


### PR DESCRIPTION
## Description

The `sys.exit(1)` was at the same indentation level as the `try` block, causing it to run unconditionally after subprocess completes - even when the command succeeds. This fix moves `sys.exit(1)` inside the `except` block.

## Bug Details

In the `run_command` function, when `log_step` is `None` (the `else` branch), the `sys.exit(1)` was placed outside the `except` block:

```python
else:
    try:
        subprocess.run(command, shell=shell, check=True)
    except subprocess.CalledProcessError as e:
        logging.error(f"Error occurred while running command: {e}")
    sys.exit(1)  # BUG: Runs unconditionally!
```

The fix properly indents `sys.exit(1)` to be inside the `except` block.

## Affected Files

- `setup_env.py` (line ~110)
- `utils/e2e_benchmark.py` (line ~23)

## Related Issue

This PR addresses issue #447