### PR TITLE
fix: Windows build and sys.exit indentation

### DIFF
--- a/setup_env.py
+++ b/setup_env.py
@@ -104,7 +104,7 @@ def run_command(command, shell=False, log_step=None):
             subprocess.run(command, shell=shell, check=True)
         except subprocess.CalledProcessError as e:
             logging.error(f"Error occurred while running command: {e}")
-        sys.exit(1)
+            sys.exit(1)
 
 def prepare_model():
     _, arch = system_info()

--- a/setup_env.py
+++ b/setup_env.py
@@ -211,7 +211,11 @@ def compile():
         logging.error(f"Arch {arch} is not supported yet")
         exit(0)
     logging.info("Compiling the code using CMake.")
-    run_command(["cmake", "-B", "build", *COMPILER_EXTRA_ARGS[arch], *OS_EXTRA_ARGS.get(platform.system(), []), "-DCMAKE_C_COMPILER=clang", "-DCMAKE_CXX_COMPILER=clang++"], log_step="generate_build_files")
+    # On Windows with ClangCL toolset, don't explicitly set compiler paths
+    if platform.system() == "Windows":
+        run_command(["cmake", "-B", "build", *COMPILER_EXTRA_ARGS[arch], "-T", "ClangCL"], log_step="generate_build_files")
+    else:
+        run_command(["cmake", "-B", "build", *COMPILER_EXTRA_ARGS[arch], "-DCMAKE_C_COMPILER=clang", "-DCMAKE_CXX_COMPILER=clang++"], log_step="generate_build_files")
     # run_command(["cmake", "--build", "build", "--target", "llama-cli", "--config", "Release"])
     run_command(["cmake", "--build", "build", "--config", "Release"], log_step="compile")
 

--- a/src/ggml-bitnet-mad.cpp
+++ b/src/ggml-bitnet-mad.cpp
@@ -808,7 +808,7 @@ void ggml_vec_dot_i2_i8_s_Nx1(int n, float * s, size_t bs, const void * vx, size
             accu[iy] = _mm256_setzero_si256();
         }
 
-        int8_t * y_col = y + col * by;
+        const int8_t * y_col = y + col * by;
         
         for (int i = 0; i < group32_num; i++) {
             const uint8_t *px = x + i * 1024;

--- a/utils/e2e_benchmark.py
+++ b/utils/e2e_benchmark.py
@@ -20,7 +20,7 @@ def run_command(command, shell=False, log_step=None):
             subprocess.run(command, shell=shell, check=True)
         except subprocess.CalledProcessError as e:
             logging.error(f"Error occurred while running command: {e}")
-        sys.exit(1)
+            sys.exit(1)
 
 def run_benchmark():
     build_dir =  os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "build")


### PR DESCRIPTION
## Summary

Multiple fixes for BitNet:

### Fix 1: Windows build - compiler flags (new)
Fixes issue #493 - On Windows with `-T ClangCL` toolset, explicitly setting `CMAKE_C_COMPILER=clang` causes CMake configuration to fail. Fix: Only pass these compiler flags on non-Windows platforms.

### Fix 2: ggml-bitnet-mad.cpp missing const qualifier (new)
Compilation fails with error: `cannot initialize a variable of type int8_t* with an rvalue of type const int8_t*`. Fix: Add `const` qualifier to `y_col` pointer declaration.

### Original Fix: sys.exit(1) indentation
The sys.exit(1) was at the same indentation as try:, causing it to run unconditionally after subprocess completes - even on success. Existed in two files:
- setup_env.py line 107
- utils/e2e_benchmark.py line 23

Fixes #447