### PR TITLE
Fix: sys.exit(1) runs unconditionally due to indentation bug

### DIFF
--- a/setup_env.py
+++ b/setup_env.py
@@ -104,7 +104,7 @@ def run_command(command, shell=False, log_step=None):
             subprocess.run(command, shell=shell, check=True)
         except subprocess.CalledProcessError as e:
             logging.error(f"Error occurred while running command: {e}")
-        sys.exit(1)
+            sys.exit(1)
 
 def prepare_model():
     _, arch = system_info()

--- a/utils/e2e_benchmark.py
+++ b/utils/e2e_benchmark.py
@@ -20,7 +20,7 @@ def run_command(command, shell=False, log_step=None):
             subprocess.run(command, shell=shell, check=True)
         except subprocess.CalledProcessError as e:
             logging.error(f"Error occurred while running command: {e}")
-        sys.exit(1)
+            sys.exit(1)
 
 def run_benchmark():
     build_dir =  os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "build")


### PR DESCRIPTION
## Summary

The sys.exit(1) was at the wrong indentation level (outside the except block), causing it to always run after the subprocess completes, even when the command succeeds.

This fix moves sys.exit(1) inside the except block so it only runs when subprocess.run raises a CalledProcessError.

## Files Changed

- setup_env.py (line 108): Fixed indentation
- utils/e2e_benchmark.py (line 23): Fixed indentation

## Related Issue

Fixes issue #447