### PR TITLE
fix: handle unsupported architectures gracefully in setup_env.py

### DIFF
--- a/setup_env.py
+++ b/setup_env.py
@@ -82,7 +82,7 @@ ARCH_ALIAS = {
 }
 
 def system_info():
-    return platform.system(), ARCH_ALIAS[platform.machine()]
+    return platform.system(), ARCH_ALIAS.get(platform.machine(), platform.machine())
 
 def get_model_name():
     if args.hf_repo:
@@ -209,7 +209,7 @@ def compile():
     _, arch = system_info()
     if arch not in COMPILER_EXTRA_ARGS.keys():
         logging.error(f"Arch {arch} is not supported yet")
-        exit(0)
+        sys.exit(1)
     logging.info("Compiling the code using CMake.")
     run_command(["cmake", "-B", "build", *COMPILER_EXTRA_ARGS[arch], *OS_EXTRA_ARGS.get(platform.system(), []), "-DCMAKE_C_COMPILER=clang", "-DCMAKE_CXX_COMPILER=clang++"], log_step="generate_build_files")
     # run_command(["cmake", "--build", "build", "--target", "llama-cli", "--config", "Release"])
@@ -223,6 +223,9 @@ def main():
     
 def parse_args():
     _, arch = system_info()
+    if arch not in SUPPORTED_QUANT_TYPES:
+        logging.error(f"Unsupported architecture: {platform.machine()} (resolved as '{arch}')")
+        sys.exit(1)
     parser = argparse.ArgumentParser(description='Setup the environment for running the inference')
     parser.add_argument("--hf-repo", "-hr", type=str, help="Model used for inference", choices=SUPPORTED_HF_MODELS.keys())
     parser.add_argument("--model-dir", "-md", type=str, help="Directory to save/load the model", default="models")


### PR DESCRIPTION
## Summary

Fixes three error-handling bugs in `setup_env.py` that cause crashes or misleading exit codes on unsupported platforms.

**Bug 1 — `exit(0)` on error condition (line 212):**
`compile()` calls `exit(0)` when the architecture is unsupported, reporting success instead of failure.

**Bug 2 — `ARCH_ALIAS` KeyError on unrecognized platforms (line 85):**
`system_info()` uses a dict lookup `ARCH_ALIAS[platform.machine()]` which raises `KeyError` for architectures not in the alias table (e.g. `i686`, `riscv64`, `ppc64le`). This crashes before the architecture check in `compile()` can provide a proper error message.

**Bug 3 — `parse_args()` KeyError on unsupported arch (line 225):**
`parse_args()` uses `SUPPORTED_QUANT_TYPES[arch]` for argparse `choices`, which also raises `KeyError` for unknown architectures.

## Changes

- `setup_env.py:85`: Changed `ARCH_ALIAS[platform.machine()]` to `ARCH_ALIAS.get(platform.machine(), platform.machine())` — unknown architectures now pass through instead of crashing.
- `setup_env.py:212`: Changed `exit(0)` to `sys.exit(1)` — error condition now reports failure correctly.
- `setup_env.py:225-228`: Added early arch check in `parse_args()` with a clear error message before argparse tries to use the unsupported arch.

## Testing

- Known architectures (`AMD64`, `x86_64`, `aarch64`, `arm64`, `ARM64`) behave identically to before
- Unknown architectures now get a clear error message instead of an unhandled `KeyError` traceback
- All changes are backward-compatible with existing supported platforms
- No unrelated changes included

Made with [Cursor](https://cursor.com)