### PR TITLE
fix: change y_col to const int8_t pointer for better type safety - this is needed for intel mac setup using conda

### DIFF
--- a/src/ggml-bitnet-mad.cpp
+++ b/src/ggml-bitnet-mad.cpp
@@ -808,7 +808,7 @@ void ggml_vec_dot_i2_i8_s_Nx1(int n, float * s, size_t bs, const void * vx, size
             accu[iy] = _mm256_setzero_si256();
         }
 
-        int8_t * y_col = y + col * by;
+        const int8_t * y_col = y + col * by;
         
         for (int i = 0; i < group32_num; i++) {
             const uint8_t *px = x + i * 1024;


### PR DESCRIPTION
hi, a summary of what this fixes:

## PR Description: Fix const-correctness in `ggml-bitnet-mad.cpp` for Clang compatibility

### Summary
This PR fixes a build-breaking compilation error on macOS (Apple Clang) by correctly qualifying `y_col` as a `const` pointer in `src/ggml-bitnet-mad.cpp`.

### The Problem
When building on macOS using **Apple Clang (version 17.0.0+)**, the compiler throws the following error:

> `error: cannot initialize a variable of type 'int8_t *' (aka 'signed char *') with an rvalue of type 'const int8_t *' (aka 'const signed char *')`

This occurs because the variable `y` is passed or cast as a `const` pointer. Performing pointer arithmetic on it (e.g., `y + col * by`) results in a `const` pointer. Assigning this result to a non-const `int8_t * y_col` violates C++ type safety by implicitly discarding the `const` qualifier. 

While some versions of GCC might only issue a warning, modern Clang—especially on Apple Silicon—treats this as a fatal error by default or under strict build flags.

### The Fix
The variable `y_col` is only used for read operations in the subsequent logic. By changing the declaration to `const int8_t * y_col`, we:
1.  **Resolve the compilation error** on macOS/Clang.
2.  **Ensure const-correctness**, preventing accidental writes to read-only memory.
3.  **Maintain compatibility** across different compiler toolchains (GCC, Clang, MSVC).
