### PR TITLE
fix: add const qualifier to y_col pointer (Clang 20 compatibility)

### DIFF
--- a/src/ggml-bitnet-mad.cpp
+++ b/src/ggml-bitnet-mad.cpp
@@ -808,7 +808,7 @@ void ggml_vec_dot_i2_i8_s_Nx1(int n, float * s, size_t bs, const void * vx, size
             accu[iy] = _mm256_setzero_si256();
         }
 
-        int8_t * y_col = y + col * by;
+        const int8_t * y_col = y + col * by;
         
         for (int i = 0; i < group32_num; i++) {
             const uint8_t *px = x + i * 1024;


### PR DESCRIPTION
## Summary

Line 811 in `src/ggml-bitnet-mad.cpp` initializes `y_col` as `int8_t*` but it is only read from (used as `const` in the `py` pointer below).

## Problem

Clang 20 is stricter about const-correctness and throws error:
```
cannot initialize a variable of type int8_t* with an rvalue of type const int8_t*
```

## Fix

Changed line 811 from:
```cpp
int8_t * y_col = y + col * by;
```
to:
```cpp
const int8_t * y_col = y + col * by;
```

This fix aligns with line 906 which already uses `const int8_t*`.

## Testing

This fix resolves the Clang 20 build error on Ubuntu 24.04.