### PR TITLE
fix: move sys.exit(1) inside except block in run_command()

### DIFF
--- a/setup_env.py
+++ b/setup_env.py
@@ -104,7 +104,7 @@ def run_command(command, shell=False, log_step=None):
             subprocess.run(command, shell=shell, check=True)
         except subprocess.CalledProcessError as e:
             logging.error(f"Error occurred while running command: {e}")
-        sys.exit(1)
+            sys.exit(1)
 
 def prepare_model():
     _, arch = system_info()

--- a/src/ggml-bitnet-mad.cpp
+++ b/src/ggml-bitnet-mad.cpp
@@ -808,7 +808,7 @@ void ggml_vec_dot_i2_i8_s_Nx1(int n, float * s, size_t bs, const void * vx, size
             accu[iy] = _mm256_setzero_si256();
         }
 
-        int8_t * y_col = y + col * by;
+        const int8_t * y_col = y + col * by;
         
         for (int i = 0; i < group32_num; i++) {
             const uint8_t *px = x + i * 1024;


### PR DESCRIPTION
The sys.exit(1) was incorrectly placed outside the except block in setup_env.py, causing it to run unconditionally after the try/except completes, regardless of whether the command succeeded or failed.

**Before:**
```python
except subprocess.CalledProcessError as e:
    logging.error(f"Error occurred while running command: {e}")
sys.exit(1)  # Runs always!
```

**After:**
```python
except subprocess.CalledProcessError as e:
    logging.error(f"Error occurred while running command: {e}")
    sys.exit(1)  # Runs only on error
```

Fixes: #447