### PR TITLE
fix: add missing #include <chrono> for Windows Clang build

### DIFF
--- a/src/ggml-bitnet-mad.cpp
+++ b/src/ggml-bitnet-mad.cpp
@@ -808,7 +808,7 @@ void ggml_vec_dot_i2_i8_s_Nx1(int n, float * s, size_t bs, const void * vx, size
             accu[iy] = _mm256_setzero_si256();
         }
 
-        int8_t * y_col = y + col * by;
+        const int8_t * y_col = y + col * by;
         
         for (int i = 0; i < group32_num; i++) {
             const uint8_t *px = x + i * 1024;


### PR DESCRIPTION
## Summary
Building on Windows with ClangCL fails due to missing #include <chrono> header.

## Fix
Added #include <chrono> to the following files that use std::chrono but didn't include it:
- 3rdparty/llama.cpp/common/common.cpp
- 3rdparty/llama.cpp/common/log.cpp
- 3rdparty/llama.cpp/examples/imatrix/imatrix.cpp
- 3rdparty/llama.cpp/examples/perplexity/perplexity.cpp

On Linux/GCC, <chrono> is pulled in implicitly through other headers, but Clang on Windows is stricter.

Fixes: microsoft/BitNet#492