### PR TITLE
fix: make gguf installation optional to avoid breaking custom venvs

### DIFF
--- a/setup_env.py
+++ b/setup_env.py
@@ -150,7 +150,16 @@ def prepare_model():
         logging.info(f"GGUF model already exists at {gguf_path}")
 
 def setup_gguf():
-    # Install the pip package
+    # Install the pip package (only if --install-gguf flag is set)
+    if not args.install_gguf:
+        # Check if gguf is already installed
+        try:
+            import gguf
+            logging.info("gguf package already installed, skipping installation.")
+            return
+        except ImportError:
+            pass
+    
     run_command([sys.executable, "-m", "pip", "install", "3rdparty/llama.cpp/gguf-py"], log_step="install_gguf")
 
 def gen_code():
@@ -230,6 +239,7 @@ def parse_args():
     parser.add_argument("--quant-type", "-q", type=str, help="Quantization type", choices=SUPPORTED_QUANT_TYPES[arch], default="i2_s")
     parser.add_argument("--quant-embd", action="store_true", help="Quantize the embeddings to f16")
     parser.add_argument("--use-pretuned", "-p", action="store_true", help="Use the pretuned kernel parameters")
+    parser.add_argument("--install-gguf", "-ig", action="store_true", help="Force install gguf-py package (default: skip if already installed)")
     return parser.parse_args()
 
 def signal_handler(sig, frame):

--- a/src/ggml-bitnet-mad.cpp
+++ b/src/ggml-bitnet-mad.cpp
@@ -808,7 +808,7 @@ void ggml_vec_dot_i2_i8_s_Nx1(int n, float * s, size_t bs, const void * vx, size
             accu[iy] = _mm256_setzero_si256();
         }
 
-        int8_t * y_col = y + col * by;
+        const int8_t * y_col = y + col * by;
         
         for (int i = 0; i < group32_num; i++) {
             const uint8_t *px = x + i * 1024;


### PR DESCRIPTION
## Summary

Fixes issue #498: setup_env.py triggers unwanted pip install

## Problem

The  script unconditionally calls  which runs:
```
sys.executable -m pip install 3rdparty/llama.cpp/gguf-py
```

This breaks custom or virtual Python environments due to forced pip installation, causing dependency/version conflicts.

## Solution

- Add  (or ) flag to force installation when needed
- Default behavior now checks if gguf is already installed before installing
- If gguf is already present, skip the installation step

## Changes

- Modified  to check for existing gguf installation
- Added  /  argument to force installation

## Usage

```bash
# Default: skip installation if gguf already installed
python setup_env.py

# Force installation (original behavior)
python setup_env.py --install-gguf
```

Co-authored-by: Jah-yee <jah-yee@users.noreply.github.com>