### PR TITLE
feat: add --skip-gguf-install flag to avoid unconditional pip install

### DIFF
--- a/setup_env.py
+++ b/setup_env.py
@@ -150,6 +150,10 @@ def prepare_model():
         logging.info(f"GGUF model already exists at {gguf_path}")
 
 def setup_gguf():
+    # Skip if --skip-gguf-install flag is provided
+    if args.skip_gguf_install:
+        logging.info("Skipping gguf-py installation (--skip-gguf-install flag set)")
+        return
     # Install the pip package
     run_command([sys.executable, "-m", "pip", "install", "3rdparty/llama.cpp/gguf-py"], log_step="install_gguf")
 
@@ -230,6 +234,7 @@ def parse_args():
     parser.add_argument("--quant-type", "-q", type=str, help="Quantization type", choices=SUPPORTED_QUANT_TYPES[arch], default="i2_s")
     parser.add_argument("--quant-embd", action="store_true", help="Quantize the embeddings to f16")
     parser.add_argument("--use-pretuned", "-p", action="store_true", help="Use the pretuned kernel parameters")
+    parser.add_argument("--skip-gguf-install", action="store_true", help="Skip automatic installation of gguf-py (assume already installed)")
     return parser.parse_args()
 
 def signal_handler(sig, frame):


### PR DESCRIPTION
Add command-line flag to make gguf-py installation optional, addressing issue #498 where setup_env.py triggers unwanted pip install causing environment conflicts in custom/virtual Python environments.

Users can now run:
```bash
python setup_env.py --skip-gguf-install
```

To skip the automatic pip install step. This is useful for:
- CI/CD pipelines with pre-installed dependencies
- Docker containers with fixed environments  
- Users with custom virtual environments

## Changes
- Added `--skip-gguf-install` argument to parse_args()
- Modified setup_gguf() to check args.skip_gguf_install before installing

Fixes #498