### PR TITLE
fix: correct error handling in setup_env.py and e2e_benchmark.py

### DIFF
--- a/setup_env.py
+++ b/setup_env.py
@@ -82,7 +82,7 @@ ARCH_ALIAS = {
 }
 
 def system_info():
-    return platform.system(), ARCH_ALIAS[platform.machine()]
+    return platform.system(), ARCH_ALIAS.get(platform.machine(), platform.machine())
 
 def get_model_name():
     if args.hf_repo:
@@ -104,7 +104,7 @@ def run_command(command, shell=False, log_step=None):
             subprocess.run(command, shell=shell, check=True)
         except subprocess.CalledProcessError as e:
             logging.error(f"Error occurred while running command: {e}")
-        sys.exit(1)
+            sys.exit(1)
 
 def prepare_model():
     _, arch = system_info()
@@ -209,7 +209,7 @@ def compile():
     _, arch = system_info()
     if arch not in COMPILER_EXTRA_ARGS.keys():
         logging.error(f"Arch {arch} is not supported yet")
-        exit(0)
+        sys.exit(1)
     logging.info("Compiling the code using CMake.")
     run_command(["cmake", "-B", "build", *COMPILER_EXTRA_ARGS[arch], *OS_EXTRA_ARGS.get(platform.system(), []), "-DCMAKE_C_COMPILER=clang", "-DCMAKE_CXX_COMPILER=clang++"], log_step="generate_build_files")
     # run_command(["cmake", "--build", "build", "--target", "llama-cli", "--config", "Release"])
@@ -223,6 +223,9 @@ def main():
     
 def parse_args():
     _, arch = system_info()
+    if arch not in SUPPORTED_QUANT_TYPES:
+        logging.error(f"Unsupported architecture: {arch}")
+        sys.exit(1)
     parser = argparse.ArgumentParser(description='Setup the environment for running the inference')
     parser.add_argument("--hf-repo", "-hr", type=str, help="Model used for inference", choices=SUPPORTED_HF_MODELS.keys())
     parser.add_argument("--model-dir", "-md", type=str, help="Directory to save/load the model", default="models")

--- a/utils/e2e_benchmark.py
+++ b/utils/e2e_benchmark.py
@@ -20,7 +20,7 @@ def run_command(command, shell=False, log_step=None):
             subprocess.run(command, shell=shell, check=True)
         except subprocess.CalledProcessError as e:
             logging.error(f"Error occurred while running command: {e}")
-        sys.exit(1)
+            sys.exit(1)
 
 def run_benchmark():
     build_dir =  os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "build")


### PR DESCRIPTION
## Summary

Fixes 5 error-handling bugs across `setup_env.py` and `utils/e2e_benchmark.py`:

1. **`setup_env.py:107` - `sys.exit(1)` indentation bug**: The `sys.exit(1)` call in `run_command()` is outside the `except` block, causing unconditional exit after any command run through the non-logging path. Fixed by indenting it into the `except` block.

2. **`e2e_benchmark.py:23` - same indentation bug**: Identical `sys.exit(1)` indentation issue. This one is actively triggered since `run_benchmark()` calls `run_command(command)` without `log_step`, so the benchmark always exits with code 1 after successful runs.

3. **`setup_env.py:212` - `exit(0)` on error**: When the architecture is unsupported, `exit(0)` reports success. Changed to `sys.exit(1)` to correctly signal failure.

4. **`setup_env.py:85` - `ARCH_ALIAS` KeyError**: `ARCH_ALIAS[platform.machine()]` crashes with `KeyError` on unrecognized architectures (e.g., `i686`, `riscv64`, `ppc64le`). Changed to `.get()` with fallback to the raw machine string, so the architecture check downstream can provide a proper error message.

5. **`setup_env.py:225` - `SUPPORTED_QUANT_TYPES` KeyError**: `SUPPORTED_QUANT_TYPES[arch]` in `parse_args()` crashes for unknown architectures before argparse can run. Added a guard that logs an error and exits cleanly.

## Testing

- `python3 -m py_compile setup_env.py` - passes
- `python3 -m py_compile utils/e2e_benchmark.py` - passes
- Verified on `x86_64` and `arm64` that existing behavior is unchanged

Fixes #447