### PR TITLE
Fix const correctness bug in ggml-bitnet-mad.cpp (line 811)

### DIFF
--- a/src/ggml-bitnet-mad.cpp
+++ b/src/ggml-bitnet-mad.cpp
@@ -808,7 +808,7 @@ void ggml_vec_dot_i2_i8_s_Nx1(int n, float * s, size_t bs, const void * vx, size
             accu[iy] = _mm256_setzero_si256();
         }
 
-        int8_t * y_col = y + col * by;
+        const int8_t * y_col = y + col * by;
         
         for (int i = 0; i < group32_num; i++) {
             const uint8_t *px = x + i * 1024;


### PR DESCRIPTION
The compiler errors because a non-const pointer (int8_t*) was being 
assigned from a const pointer (const int8_t*).

Fix: add `const` to the pointer declaration on line 811.

Before: int8_t * y_col = y + col * by;
After:  const int8_t * y_col = y + col * by;

The error's log:
```
/content/BitNet/src/ggml-bitnet-mad.cpp:811:18: error: cannot initialize a variable of type 'int8_t *' (aka 'signed char *') with an rvalue of type 'const int8_t *' (aka 'const signed char *')

  811 |         int8_t * y_col = y + col * by;

      |                  ^       ~~~~~~~~~~~~

```