### PR TITLE
[fix] add --ub 16 to run_server

### DIFF
--- a/run_inference_server.py
+++ b/run_inference_server.py
@@ -29,6 +29,7 @@ def run_server():
         '-t', str(args.threads),
         '-n', str(args.n_predict),
         '-ngl', '0',
+        '-ub', '16',
         '--temp', str(args.temperature),
         '--host', args.host,
         '--port', str(args.port),


### PR DESCRIPTION
- A ubatch_size greater than 16 causes a segmentation fault.
- fixes: https://github.com/microsoft/BitNet/issues/517