### PR TITLE
Add huggingface_hub requirement to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ This project is based on the [llama.cpp](https://github.com/ggerganov/llama.cpp)
 - python>=3.9
 - cmake>=3.22
 - clang>=18
+- huggingface_hub>=0.20.0
     - For Windows users, install [Visual Studio 2022](https://visualstudio.microsoft.com/downloads/). In the installer, toggle on at least the following options(this also automatically installs the required additional tools like CMake):
         -  Desktop-development with C++
         -  C++-CMake Tools for Windows


### PR DESCRIPTION
## What this PR fixes

When following the setup instructions, `huggingface-cli` is not available  after running `pip install -r requirements.txt` because `huggingface_hub`  is not listed as a dependency.

This can be confusing for beginners who follow the instructions step by step.

## Changes
- Added `huggingface_hub` to requirements.txt

## How I found this
I followed the instructions as a first-time user and encountered this issue.