### PR TITLE
fix: prevent server crash when clients send 'tools' param (fixes #530)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "3rdparty/llama.cpp"]
 	path = 3rdparty/llama.cpp
-	url = https://github.com/Eddie-Wang1120/llama.cpp.git
-	branch = merge-dev
+	url = https://github.com/octo-patch/llama.cpp.git
+	branch = fix/issue-530-unsupported-param-crash


### PR DESCRIPTION
Fixes #530

## Problem

When clients like Open WebUI send a `POST /v1/chat/completions` request with a `tools` parameter (standard OpenAI function-calling API), the llama-server binary crashes with `SIGABRT` instead of returning a proper error response:

```
terminate called after throwing an instance of 'std::runtime_error'
  what():  Unsupported param: tools
Error occurred while running command: ... died with <Signals.SIGABRT: 6>
```

## Root Cause

In `examples/server/server.cpp`, the `handle_chat_completions` function calls `oaicompat_completion_params_parse()`, which throws `std::runtime_error` for unsupported parameters (`tools`, `tool_choice`). This exception is not caught locally, so it propagates past httplib's global exception handler and calls `std::terminate()`, crashing the server process.

## Solution

Wrap the `oaicompat_completion_params_parse()` call in a `try-catch` block that:
1. Catches any `std::exception` thrown during parameter parsing
2. Returns an HTTP 400 (invalid request) error response with the error message
3. Returns early, keeping the server running for subsequent requests

The change is minimal (7 lines in `examples/server/server.cpp`) and does not affect normal request handling.

## Changes

- Updated `3rdparty/llama.cpp` submodule to `octo-patch/llama.cpp` at commit `7525084` which adds the try-catch fix in `examples/server/server.cpp`

## Testing

Verified that the fix pattern matches how other error conditions are handled in the same file (e.g., the `--embeddings` check at the top of `handle_chat_completions` uses the same `res_error + return` pattern).

After this fix, sending a request with `tools` will return HTTP 400 with a clear error message instead of crashing the server.