### PR TITLE
Clean up minor code smells across Python and C++ sources

### DIFF
--- a/gpu/bitnet_kernels/bitnet_kernels.h
+++ b/gpu/bitnet_kernels/bitnet_kernels.h
@@ -2,7 +2,6 @@
 #include <math_constants.h>
 #include <math.h>
 #include <mma.h>
-#include <iostream>
 #include <cuda.h>
 #include <cuda_fp16.h>
 #include <cuda_bf16.h>
@@ -15,9 +14,9 @@
 #endif
 
 #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ == 800
-#define TVM_ENBALE_EFFICIENT_SMEM_PTR_CAST 1
+#define TVM_ENABLE_EFFICIENT_SMEM_PTR_CAST 1
 #else
-#define TVM_ENBALE_EFFICIENT_SMEM_PTR_CAST 0
+#define TVM_ENABLE_EFFICIENT_SMEM_PTR_CAST 0
 #endif
 
 template <typename T1, typename T2>

--- a/setup_env.py
+++ b/setup_env.py
@@ -209,7 +209,7 @@ def compile():
     _, arch = system_info()
     if arch not in COMPILER_EXTRA_ARGS.keys():
         logging.error(f"Arch {arch} is not supported yet")
-        exit(0)
+        sys.exit(1)
     logging.info("Compiling the code using CMake.")
     run_command(["cmake", "-B", "build", *COMPILER_EXTRA_ARGS[arch], *OS_EXTRA_ARGS.get(platform.system(), []), "-DCMAKE_C_COMPILER=clang", "-DCMAKE_CXX_COMPILER=clang++"], log_step="generate_build_files")
     # run_command(["cmake", "--build", "build", "--target", "llama-cli", "--config", "Release"])

--- a/src/ggml-bitnet-lut.cpp
+++ b/src/ggml-bitnet-lut.cpp
@@ -1,9 +1,9 @@
 #include <vector>
 #include <type_traits>
 
-#include <string.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstring>
+#include <cstdio>
+#include <cstdlib>
 
 #include "ggml-bitnet.h"
 #include "ggml-quants.h"

--- a/src/ggml-bitnet-mad.cpp
+++ b/src/ggml-bitnet-mad.cpp
@@ -1,6 +1,6 @@
 #include <vector>
 #include <type_traits>
-#include <assert.h>
+#include <cassert>
 #include "ggml-bitnet.h"
 #include "ggml-quants.h"
 #include "gemm-config.h"

--- a/utils/codegen_tl1.py
+++ b/utils/codegen_tl1.py
@@ -418,7 +418,7 @@ if __name__ == "__main__":
 
     output_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "include")
 
-    with open(''.join([output_dir, "/bitnet-lut-kernels.h"]), 'w') as f:
+    with open(os.path.join(output_dir, "bitnet-lut-kernels.h"), 'w') as f:
         f.write(''.join("#if defined(GGML_BITNET_ARM_TL1)"))
         f.write(''.join(ctor_code))
         for code in tbl_impl_code:
@@ -432,11 +432,11 @@ if __name__ == "__main__":
 
     for i in range(len(kernel_shapes)):
         config.add_section('Kernels_{}'.format(i))
-        config.set('Kernels_{}'.format(i), 'M'.format(i), str(kernel_shapes[i][0]))
-        config.set('Kernels_{}'.format(i), 'K'.format(i), str(kernel_shapes[i][1]))
-        config.set('Kernels_{}'.format(i), 'BM'.format(i), str(BM_list[i]))
-        config.set('Kernels_{}'.format(i), 'BK'.format(i), str(BK_list[i]))
-        config.set('Kernels_{}'.format(i), 'bmm'.format(i), str(bm_list[i]))
+        config.set('Kernels_{}'.format(i), 'M', str(kernel_shapes[i][0]))
+        config.set('Kernels_{}'.format(i), 'K', str(kernel_shapes[i][1]))
+        config.set('Kernels_{}'.format(i), 'BM', str(BM_list[i]))
+        config.set('Kernels_{}'.format(i), 'BK', str(BK_list[i]))
+        config.set('Kernels_{}'.format(i), 'bmm', str(bm_list[i]))
 
-    with open(''.join([output_dir, "/kernel_config.ini"]), 'w') as configfile:
+    with open(os.path.join(output_dir, "kernel_config.ini"), 'w') as configfile:
         config.write(configfile)

--- a/utils/codegen_tl2.py
+++ b/utils/codegen_tl2.py
@@ -734,7 +734,7 @@ if __name__ == "__main__":
 
     output_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "include")
 
-    with open(''.join([output_dir, "/bitnet-lut-kernels.h"]), 'w') as f:
+    with open(os.path.join(output_dir, "bitnet-lut-kernels.h"), 'w') as f:
         f.write(''.join("#if defined(GGML_BITNET_X86_TL2)"))
         f.write(''.join(ctor_code))
         for code in tbl_impl_code:
@@ -747,11 +747,11 @@ if __name__ == "__main__":
 
     for i in range(len(kernel_shapes)):
         config.add_section('Kernels_{}'.format(i))
-        config.set('Kernels_{}'.format(i), 'M'.format(i), str(kernel_shapes[i][0]))
-        config.set('Kernels_{}'.format(i), 'K'.format(i), str(kernel_shapes[i][1]))
-        config.set('Kernels_{}'.format(i), 'BM'.format(i), str(BM_list[i]))
-        config.set('Kernels_{}'.format(i), 'BK'.format(i), str(BK_list[i]))
-        config.set('Kernels_{}'.format(i), 'bmm'.format(i), str(bm_list[i]))
+        config.set('Kernels_{}'.format(i), 'M', str(kernel_shapes[i][0]))
+        config.set('Kernels_{}'.format(i), 'K', str(kernel_shapes[i][1]))
+        config.set('Kernels_{}'.format(i), 'BM', str(BM_list[i]))
+        config.set('Kernels_{}'.format(i), 'BK', str(BK_list[i]))
+        config.set('Kernels_{}'.format(i), 'bmm', str(bm_list[i]))
 
-    with open(''.join([output_dir, "/kernel_config.ini"]), 'w') as configfile:
+    with open(os.path.join(output_dir, "kernel_config.ini"), 'w') as configfile:
         config.write(configfile)

--- a/utils/generate-dummy-bitnet-model.py
+++ b/utils/generate-dummy-bitnet-model.py
@@ -2,8 +2,6 @@
 
 # dummy model generation script based on convert-hf-to-gguf-bitnet.py
 from __future__ import annotations
-import sys
-from pathlib import Path
 
 import numpy as np
 import configparser

--- a/utils/quantize_embeddings.py
+++ b/utils/quantize_embeddings.py
@@ -168,7 +168,7 @@ class EmbeddingQuantizer:
                 print("\n📊 Benchmark output:")
                 print(result.stdout)
                 
-                # 解析输出
+                # Parse output
                 bench_results = self.parse_benchmark_output(result.stdout, output_suffix)
                 return bench_results
             else:
@@ -223,7 +223,7 @@ class EmbeddingQuantizer:
                 # Extract thread count
                 try:
                     threads = int(threads_str)
-                except:
+                except (ValueError, TypeError):
                     continue
                 
                 # Extract t/s data (format: "405.73 ± 3.69" or "405.73")
@@ -320,14 +320,14 @@ class EmbeddingQuantizer:
         total_end = datetime.now()
         total_duration = (total_end - total_start).total_seconds()
         
-        # 保存结果到CSV
+        # Save results to CSV
         self.save_results_to_csv()
-        
-        # 打印总结
+
+        # Print summary
         self.print_summary(total_duration)
     
     def save_results_to_csv(self):
-        """将benchmark结果保存到CSV文件"""
+        """Save benchmark results to a CSV file."""
         if not self.results:
             print("⚠️  No results to save")
             return
@@ -435,9 +435,9 @@ def main():
     # If specific types are specified, filter the list
     if args.types:
         types_lower = [t.lower() for t in args.types]
-        types_to_quantize = [(et, os) for et, os in all_types if os.lower() in types_lower]
+        types_to_quantize = [(et, qs) for et, qs in all_types if qs.lower() in types_lower]
         if not types_to_quantize:
-            print(f"❌ No valid types specified. Available types: {', '.join([os for _, os in all_types])}")
+            print(f"❌ No valid types specified. Available types: {', '.join([qs for _, qs in all_types])}")
             return
     else:
         types_to_quantize = all_types
@@ -445,7 +445,7 @@ def main():
     # If skip existing files is enabled, no need to filter
     # Because new logic will automatically detect and skip during quantization, but will still benchmark
     
-    # 创建量化器并运行
+    # Create quantizer and run
     try:
         quantizer = EmbeddingQuantizer(
             args.input, 

--- a/utils/test_perplexity.py
+++ b/utils/test_perplexity.py
@@ -109,7 +109,7 @@ class PerplexityTester:
         for temp_file in self.temp_files:
             try:
                 os.unlink(temp_file)
-            except:
+            except OSError:
                 pass
         self.temp_files = []
     

--- a/utils/tune_gemm_config.py
+++ b/utils/tune_gemm_config.py
@@ -81,7 +81,7 @@ class GemmTuner:
             capture_output=True,
             text=True,
             cwd=os.getcwd(),
-            timeout=300  # 5分钟超时
+            timeout=300  # 5 minute timeout
         )
         
         if result.returncode != 0:
@@ -92,7 +92,7 @@ class GemmTuner:
         
     def parse_throughput(self, output):
         """Parse pp128 throughput from output"""
-        # 匹配 pp128: |         pp128 |       501.06 ± 11.37 |
+        # Match pp128: |         pp128 |       501.06 ± 11.37 |
         pp_pattern = r'\|\s+pp128\s+\|\s+([\d.]+)\s+±\s+([\d.]+)\s+\|'
         pp_match = re.search(pp_pattern, output)
         


### PR DESCRIPTION
During one of our regular pair programming sessions, we were browsing through the codebase and noticed a handful of small things that are easy to overlook in a fast-moving project — the kind of stuff that nobody prioritizes because it never breaks anything, but quietly adds up over time.

None of these are critical, but we figured it was worth cleaning them up in a single pass while we had fresh eyes on the code.

## Changes

- Replace bare `except` clauses with specific exception types (`OSError`, `ValueError`)
- Remove duplicate `import sys` / `from pathlib import Path` in `generate-dummy-bitnet-model.py`
- Fix `.format(i)` calls on config keys that had no `{}` placeholders — they silently did nothing
- Use `os.path.join()` instead of string concatenation for building file paths (matters on Windows)
- Fix `exit(0)` being used for an error condition — should be `sys.exit(1)`
- Translate a few leftover Chinese comments to English for consistency
- Fix typo in macro name: `TVM_ENBALE_EFFICIENT_SMEM_PTR_CAST` → `TVM_ENABLE_EFFICIENT_SMEM_PTR_CAST`
- Remove unused `#include <iostream>` from CUDA kernel header
- Rename loop variable `os` that was shadowing the `os` module import
- Use C++ standard headers (`<cassert>`, `<cstring>`) instead of C equivalents in `.cpp` files