### PR TITLE
Fix const-correctness in ggml_vec_dot_i2_i8_s_Nx1 (Clang 18)

### DIFF
--- a/src/ggml-bitnet-mad.cpp
+++ b/src/ggml-bitnet-mad.cpp
@@ -808,7 +808,7 @@ void ggml_vec_dot_i2_i8_s_Nx1(int n, float * s, size_t bs, const void * vx, size
             accu[iy] = _mm256_setzero_si256();
         }
 
-        int8_t * y_col = y + col * by;
+        const int8_t * y_col = y + col * by;
         
         for (int i = 0; i < group32_num; i++) {
             const uint8_t *px = x + i * 1024;


### PR DESCRIPTION
`y_col` was declared as `int8_t*` but initialized from `y`, which is
`const int8_t*`. This fails to compile under stricter Clang versions
(e.g. Clang 18.1.8, bundled with the VS2022 Build Tools ClangCL
toolset used on Windows).

Minimal type fix, no behavior change.