### PR TITLE
fix: add BitNetForCausalLM alias and vocab fallback for BitnetModel

### DIFF
--- a/utils/convert-hf-to-gguf-bitnet.py
+++ b/utils/convert-hf-to-gguf-bitnet.py
@@ -952,13 +952,19 @@ class LlamaModel(Model):
                 raise ValueError(f"Unprocessed experts: {experts}")
 
 
-@Model.register("BitnetForCausalLM")
+@Model.register("BitnetForCausalLM", "BitNetForCausalLM")
 class BitnetModel(Model):
     model_arch = gguf.MODEL_ARCH.BITNET
 
     def set_vocab(self):
-        self._set_vocab_sentencepiece()
-        
+        try:
+            self._set_vocab_sentencepiece()
+        except FileNotFoundError:
+            try:
+                self._set_vocab_llama_hf()
+            except (FileNotFoundError, TypeError):
+                # Llama 3
+                self._set_vocab_gpt2()
     def set_gguf_parameters(self):
         super().set_gguf_parameters()
 


### PR DESCRIPTION
The model `microsoft/BitNet-b1.58-2B-4T` uses the architecture string `BitNetForCausalLM` (with a capital 'N'), but the `convert-hf-to-gguf-bitnet.py` script expected `BitnetForCausalLM`. Additionally, these newer models use BPE tokenization instead of SentencePiece, meaning they don't have a `tokenizer.model` file. This PR adds the alias to the `@Model.register` decorator and adds the same tokenizer fallback logic that `LlamaModel` uses so the conversion script can successfully process these models without throwing errors.